### PR TITLE
Stop MoPub from logging every tick while our native ad is not in view.

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdImpressionTimer.m
+++ b/MoPubSDK/Internal/Common/MPAdImpressionTimer.m
@@ -84,7 +84,7 @@ static const CGFloat kDefaultPixelCountWhenUsingPercentage = CGFLOAT_MIN;
 {
     CGFloat adViewArea = CGRectGetWidth(self.adView.bounds) * CGRectGetHeight(self.adView.bounds);
     if (adViewArea == 0) {
-        MPLogError(@"ad view area cannot be 0");
+        // MPLogError(@"ad view area cannot be 0");
         return;
     }
 


### PR DESCRIPTION
@zacwest 

This occurs for only certain kinds of MoPub native ads, particularly our direct sold ones that run through their renderer.